### PR TITLE
Add explicit callback_url

### DIFF
--- a/lib/omniauth/strategies/docusign.rb
+++ b/lib/omniauth/strategies/docusign.rb
@@ -34,6 +34,10 @@ module OmniAuth
           deep_symbolize(options.client_options).merge(site: site)
         )
       end
+      
+      def callback_url
+        full_host + script_name + callback_path
+      end
 
       private
 


### PR DESCRIPTION
This fixes the issue reported here https://github.com/omniauth/omniauth-oauth2/issues/28, where extra query parameters would make the DocuSign callback URL invalid.